### PR TITLE
Wrap DecisionRules flow inputs in input envelope

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -35,11 +35,11 @@ async function calcPriceWithRules(part: Part) {
 }
 
 async function calcPriceViaFlow(part: Part) {
-  return dr.solve(pricingFlowId, "latest", part);
+  return dr.solve(pricingFlowId, { input: part });
 }
 
 async function calcPriceViaFlowBatch(parts: Part[]) {
-  return dr.solve(pricingFlowId, "latest", parts);
+  return dr.solve(pricingFlowId, parts.map((part) => ({ input: part })));
 }
 
 const server = Bun.serve({


### PR DESCRIPTION
## Summary
- wrap per-part flow solve calls in an `{ input: part }` envelope so assignments resolve correctly
- send batch flow solves an array of `{ input: … }` payloads to keep the request shape consistent

## Testing
- not run (DecisionRules credentials required)


------
https://chatgpt.com/codex/tasks/task_e_68ca38b86b848332b4bcb3d3749d73cb